### PR TITLE
New version 0.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ cache: pip
 
 install:
   # install torch
-  - pip install  https://download.pytorch.org/whl/cpu/torch-1.1.0-cp37-cp37m-linux_x86_64.whl
+  # v.1.1.0: - pip install  https://download.pytorch.org/whl/cpu/torch-1.1.0-cp37-cp37m-linux_x86_64.whl
+  - pip install torch==1.2.0+cpu torchvision==0.4.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
   # dependencies
   - pip install pytest
   - python setup.py install

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ requirements = [
 
 setup(
     name='torchtuples',
-    version='0.0.2',
+    version='0.1.0',
     description="Model fitting for pytorch",
     author="Haavard Kvamme",
     author_email='haavard.kvamme@gmail.com',

--- a/torchtuples/__init__.py
+++ b/torchtuples/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """Haavard Kvamme"""
 __email__ = 'haavard.kvamme@gmail.com'
-__version__ = '0.0.2'
+__version__ = '0.1.0'
 
 import torchtuples.tupletree
 from torchtuples.tupletree import TupleTree, tuplefy, to_device, numpy_to_tensor, tensor_to_numpy, make_dataloader

--- a/torchtuples/_legacy_v1_1_0.py
+++ b/torchtuples/_legacy_v1_1_0.py
@@ -1,6 +1,6 @@
-"""Code copied from pytorch source. Have just changed a couple of lines.
+"""Contains some implenentations needed for torch.__version__ == 1.1.0.
 
-torch.__version__ == '1.1.0'
+Code copied from pytorch source. Have just changed a couple of lines.
 
 We have made _DataLoaderIterSlice which use a different '_worker_loop' and 'collate_fn'.
 """
@@ -11,6 +11,79 @@ import threading
 from torch._six import queue
 from torch.utils.data._utils.worker import *
 
+
+class DataLoaderSlice(torch.utils.data.dataloader.DataLoader):
+    r"""
+    Like DataLoader but works on batches instead of iterating
+    through the batch.
+
+    Data loader. Combines a dataset and a sampler, and provides
+    single- or multi-process iterators over the dataset.
+
+    Arguments:
+        dataset (Dataset): dataset from which to load the data.
+        batch_size (int, optional): how many samples per batch to load
+            (default: 1).
+        shuffle (bool, optional): set to ``True`` to have the data reshuffled
+            at every epoch (default: False).
+        sampler (Sampler, optional): defines the strategy to draw samples from
+            the dataset. If specified, ``shuffle`` must be False.
+        batch_sampler (Sampler, optional): like sampler, but returns a batch of
+            indices at a time. Mutually exclusive with batch_size, shuffle,
+            sampler, and drop_last.
+        num_workers (int, optional): how many subprocesses to use for data
+            loading. 0 means that the data will be loaded in the main process.
+            (default: 0)
+        collate_fn (callable, optional): merges a list of samples to form a mini-batch.
+            If None, we simply pass the the in put to collate_fn.
+        pin_memory (bool, optional): If ``True``, the data loader will copy tensors
+            into CUDA pinned memory before returning them.
+        drop_last (bool, optional): set to ``True`` to drop the last incomplete batch,
+            if the dataset size is not divisible by the batch size. If ``False`` and
+            the size of dataset is not divisible by the batch size, then the last batch
+            will be smaller. (default: False)
+        timeout (numeric, optional): if positive, the timeout value for collecting a batch
+            from workers. Should always be non-negative. (default: 0)
+        worker_init_fn (callable, optional): If not None, this will be called on each
+            worker subprocess with the worker id (an int in ``[0, num_workers - 1]``) as
+            input, after seeding and before data loading. (default: None)
+
+    .. note:: By default, each worker will have its PyTorch seed set to
+              ``base_seed + worker_id``, where ``base_seed`` is a long generated
+              by main process using its RNG. However, seeds for other libraies
+              may be duplicated upon initializing workers (w.g., NumPy), causing
+              each worker to return identical random numbers. (See
+              :ref:`dataloader-workers-random-seed` section in FAQ.) You may
+              use ``torch.initial_seed()`` to access the PyTorch seed for each
+              worker in :attr:`worker_init_fn`, and use it to set other seeds
+              before data loading.
+
+    .. warning:: If ``spawn`` start method is used, :attr:`worker_init_fn` cannot be an
+                 unpicklable object, e.g., a lambda function.
+    """
+    def __init__(self, dataset, batch_size=1, shuffle=False, sampler=None, batch_sampler=None,
+                 num_workers=0, collate_fn=None, pin_memory=False,
+                 drop_last=False, timeout=0, worker_init_fn=None):
+        if collate_fn is None:
+            collate_fn = DataLoaderSlice._identity
+        super().__init__(dataset, batch_size, shuffle, sampler, batch_sampler, num_workers,
+                         collate_fn, pin_memory, drop_last, timeout, worker_init_fn)
+
+    def __iter__(self):
+        return _DataLoaderIterSlice(self)
+
+    @staticmethod
+    def _identity(x):
+        '''Function returning x'''
+        return x
+
+
+
+
+##################################################################################################
+##################################################################################################
+## The following is copyed and slightly changed from pytorch source.
+##################################################################################################
 
 # This function used to be defined in this file. However, it was moved to
 # _utils/collate.py. Although it is rather hard to access this from user land

--- a/torchtuples/base.py
+++ b/torchtuples/base.py
@@ -243,7 +243,9 @@ class Model(object):
             verbose {bool} -- Print progress (default: {True})
             num_workers {int} -- Number of workers used in the dataloader (default: {0})
             shuffle {bool} -- If we should shuffle the order of the dataset (default: {True})
-            **kwargs are passed to 'make_dataloader' method.
+            **kwargs -- Passed to the 'make_dataloader' method. Set e.g. `torch_ds_dl to use
+                the TensorDataset and DataLoader provided by torch instead of the torchtuples
+                implementations.
     
         Returns:
             TrainingLogger -- Training log

--- a/torchtuples/data.py
+++ b/torchtuples/data.py
@@ -7,78 +7,8 @@ and can potentially stop workers from shutting down at each batch.
 import warnings
 import copy
 import torch
-# from torch.utils.data.dataloader import DataLoader, RandomSampler 
-# from torch.utils.data import Dataset
 import torch.utils.data
-
 import torchtuples
-from torchtuples._pytorch_dataloader import _DataLoaderIterSlice
-
-
-class _DataLoaderSlice_v1_1_0(torch.utils.data.dataloader.DataLoader):
-    r"""
-    Like DataLoader but works on batches instead of iterating
-    through the batch.
-
-    Data loader. Combines a dataset and a sampler, and provides
-    single- or multi-process iterators over the dataset.
-
-    Arguments:
-        dataset (Dataset): dataset from which to load the data.
-        batch_size (int, optional): how many samples per batch to load
-            (default: 1).
-        shuffle (bool, optional): set to ``True`` to have the data reshuffled
-            at every epoch (default: False).
-        sampler (Sampler, optional): defines the strategy to draw samples from
-            the dataset. If specified, ``shuffle`` must be False.
-        batch_sampler (Sampler, optional): like sampler, but returns a batch of
-            indices at a time. Mutually exclusive with batch_size, shuffle,
-            sampler, and drop_last.
-        num_workers (int, optional): how many subprocesses to use for data
-            loading. 0 means that the data will be loaded in the main process.
-            (default: 0)
-        collate_fn (callable, optional): merges a list of samples to form a mini-batch.
-            If None, we simply pass the the in put to collate_fn.
-        pin_memory (bool, optional): If ``True``, the data loader will copy tensors
-            into CUDA pinned memory before returning them.
-        drop_last (bool, optional): set to ``True`` to drop the last incomplete batch,
-            if the dataset size is not divisible by the batch size. If ``False`` and
-            the size of dataset is not divisible by the batch size, then the last batch
-            will be smaller. (default: False)
-        timeout (numeric, optional): if positive, the timeout value for collecting a batch
-            from workers. Should always be non-negative. (default: 0)
-        worker_init_fn (callable, optional): If not None, this will be called on each
-            worker subprocess with the worker id (an int in ``[0, num_workers - 1]``) as
-            input, after seeding and before data loading. (default: None)
-
-    .. note:: By default, each worker will have its PyTorch seed set to
-              ``base_seed + worker_id``, where ``base_seed`` is a long generated
-              by main process using its RNG. However, seeds for other libraies
-              may be duplicated upon initializing workers (w.g., NumPy), causing
-              each worker to return identical random numbers. (See
-              :ref:`dataloader-workers-random-seed` section in FAQ.) You may
-              use ``torch.initial_seed()`` to access the PyTorch seed for each
-              worker in :attr:`worker_init_fn`, and use it to set other seeds
-              before data loading.
-
-    .. warning:: If ``spawn`` start method is used, :attr:`worker_init_fn` cannot be an
-                 unpicklable object, e.g., a lambda function.
-    """
-    def __init__(self, dataset, batch_size=1, shuffle=False, sampler=None, batch_sampler=None,
-                 num_workers=0, collate_fn=None, pin_memory=False,
-                 drop_last=False, timeout=0, worker_init_fn=None):
-        if collate_fn is None:
-            collate_fn = DataLoaderSlice._identity
-        super().__init__(dataset, batch_size, shuffle, sampler, batch_sampler, num_workers,
-                         collate_fn, pin_memory, drop_last, timeout, worker_init_fn)
-
-    def __iter__(self):
-        return _DataLoaderIterSlice(self)
-
-    @staticmethod
-    def _identity(x):
-        '''Function returning x'''
-        return x
 
 
 class DataLoaderSlice(torch.utils.data.dataloader.DataLoader):
@@ -117,7 +47,8 @@ class DataLoaderSlice(torch.utils.data.dataloader.DataLoader):
 
 
 if (torch.__version__ >= '1.1.0') and (torch.__version__ < '1.2.0'):
-    DataLoaderSlice = _DataLoaderSlice_v1_1_0
+    from torchtuples import _legacy_v1_1_0
+    DataLoaderSlice = _legacy_v1_1_0.DataLoaderSlice
 
 
 class RandomSamplerContinuous(torch.utils.data.dataloader.RandomSampler):


### PR DESCRIPTION
Torchtuples now ues pytorch 1.2.0 but should (for the most part) still work with 1.1.0.
 