### PR TITLE
Allow graph objects

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.0
+current_version = 0.2.1
 commit = True
 tag = False
 
@@ -13,4 +13,3 @@ replace = version='{new_version}'
 [bumpversion:file:torchtuples/__init__.py]
 search = __version__ = '{current_version}'
 replace = __version__ = '{new_version}'
-

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ requirements = [
 
 setup(
     name='torchtuples',
-    version='0.2.0',
+    version='0.2.1',
     description="Training neural networks in PyTorch",
     long_description=readme,
     long_description_content_type='text/markdown',

--- a/tests/test_tupletree.py
+++ b/tests/test_tupletree.py
@@ -1,22 +1,25 @@
-import pytest
 import numpy as np
+import pytest
 import torch
-from torchtuples.tupletree import TupleTree, tuplefy, make_dataloader
+
 from torchtuples.testing import assert_tupletree_equal
+from torchtuples.tupletree import TupleTree, make_dataloader, tuplefy
 
 
-@pytest.mark.parametrize('inp', [1, (1, 2), ['a', 2], [1, (1, 2)]])
+@pytest.mark.parametrize("inp", [1, (1, 2), ["a", 2], [1, (1, 2)]])
 def test_tuplefy_type(inp):
     t = tuplefy(inp)
     assert type(t) is TupleTree
 
-@pytest.mark.parametrize('inp, types', [([1], tuple), ((1,), list)])
+
+@pytest.mark.parametrize("inp, types", [([1], tuple), ((1,), list)])
 def test_tuplefy_not_list(inp, types):
     t = tuplefy(inp, types=types)
     assert type(t[0]) is type(inp)
 
-@pytest.mark.parametrize('batch_size', [1, 3, 10, 12])
-@pytest.mark.parametrize('num_workers', [0, 1, 5])
+
+@pytest.mark.parametrize("batch_size", [1, 3, 10, 12])
+@pytest.mark.parametrize("num_workers", [0, 1, 5])
 def test_make_data_loader_sorted(batch_size, num_workers):
     torch.manual_seed(123)
     a = tuplefy(torch.randn(10, 3), torch.randn(10))
@@ -26,8 +29,9 @@ def test_make_data_loader_sorted(batch_size, num_workers):
         b = b + tuplefy(inp, tar).add_root()
     assert_tupletree_equal(b.cat(), a)
 
-@pytest.mark.parametrize('batch_size', [1, 3, 10, 12])
-@pytest.mark.parametrize('num_workers', [0, 1, 5])
+
+@pytest.mark.parametrize("batch_size", [1, 3, 10, 12])
+@pytest.mark.parametrize("num_workers", [0, 1, 5])
 def test_make_data_loader_unsorted(batch_size, num_workers):
     torch.manual_seed(123)
     a = tuplefy(torch.randn(10, 3), torch.randn(10))
@@ -37,8 +41,15 @@ def test_make_data_loader_unsorted(batch_size, num_workers):
         b = b + tuplefy(inp, tar).add_root()
     b = b.cat()
     assert_tupletree_equal(b.shapes(), a.shapes())
-    assert (tuplefy(a, b).apply(sum).zip_leaf().apply(lambda x: x[0]-x[1])
-            .apply(lambda x: x.max()).pipe(max) < 1e-6)
+    assert (
+        tuplefy(a, b)
+        .apply(sum)
+        .zip_leaf()
+        .apply(lambda x: x[0] - x[1])
+        .apply(lambda x: x.max())
+        .pipe(max)
+        < 1e-6
+    )
 
 
 class TestTupleTree:
@@ -46,15 +57,17 @@ class TestTupleTree:
         a = (1, (2, 3), (4, (5,)))
         a = tuplefy(a)
         b = (2, (4, 6), (8, (10,)))
-        assert a.apply(lambda x: x*2) == b
+        assert a.apply(lambda x: x * 2) == b
 
     def test_reduce(self):
-        a = ((1, (2, 3), 4),
-             (1, (2, 3), 4),
-             (1, (2, 3), 4),)
+        a = (
+            (1, (2, 3), 4),
+            (1, (2, 3), 4),
+            (1, (2, 3), 4),
+        )
         b = (3, (6, 9), 12)
         a = tuplefy(a)
-        assert a.reduce(lambda x, y: x+y) == b
+        assert a.reduce(lambda x, y: x + y) == b
 
     def test_levels(self):
         a = (1, (2, 3), (4, (5,)))
@@ -62,7 +75,7 @@ class TestTupleTree:
         assert a.levels == (0, (1, 1), (1, (2,)))
 
     def test_types(self):
-        a = ('a', (1, 4.5), {})
+        a = ("a", (1, 4.5), {})
         b = (str, (int, float), dict)
         a = tuplefy(a)
         assert a.types() == b
@@ -74,46 +87,47 @@ class TestTupleTree:
         assert a.numerate() == order
 
     def test_enumerate(self):
-        a = tuplefy(list('abcd'), list('ef'))
-        a = tuplefy((('a', 'b', 'c', 'd'), ('e', 'f')))
-        assert a.enumerate() == (([0, 'a'], [1, 'b'], [2, 'c'], [3, 'd']), ([4, 'e'], [5, 'f']))
+        a = tuplefy(list("abcd"), list("ef"))
+        a = tuplefy((("a", "b", "c", "d"), ("e", "f")))
+        assert a.enumerate() == (([0, "a"], [1, "b"], [2, "c"], [3, "d"]), ([4, "e"], [5, "f"]))
 
     def test_reorder(self):
-        a = tuplefy((('a', 'b', 'c', 'd'), ('e', 'f')))
+        a = tuplefy((("a", "b", "c", "d"), ("e", "f")))
         order = (0, (1, 2,), (5,))
-        assert a.reorder(order)  ==  ('a', ('b', 'c'), ('f',))
+        assert a.reorder(order) == ("a", ("b", "c"), ("f",))
 
     def test_repeat(self):
         a = (1, (2, 3))
         b = ((1, (2, 3)), (1, (2, 3)), (1, (2, 3)))
         assert tuplefy(a).repeat(3) == b
 
-    @pytest.mark.parametrize('a, expected',
-        [([1, 1, (1,)], 'default'), ([10, 10,], 10), ([(10, 1), (10, 1)], (10, 1))])
+    @pytest.mark.parametrize(
+        "a, expected", [([1, 1, (1,)], "default"), ([10, 10,], 10), ([(10, 1), (10, 1)], (10, 1))]
+    )
     def test_get_if_all_equal(self, a, expected):
-        out = tuplefy(a).get_if_all_equal('default')
+        out = tuplefy(a).get_if_all_equal("default")
         assert out == expected
 
     def test_zip_leaf(self):
-        a = (('a1', ('a2', 'a3')), ('b1', ('b2', 'b3')))
+        a = (("a1", ("a2", "a3")), ("b1", ("b2", "b3")))
         a = tuplefy(a)
-        b = (['a1', 'b1'], (['a2', 'b2'], ['a3', 'b3']))
+        b = (["a1", "b1"], (["a2", "b2"], ["a3", "b3"]))
         assert a.zip_leaf() == b
 
     def test_unzip_leaf(self):
-        a = (('a1', ('a2', 'a3')), ('b1', ('b2', 'b3')))
-        b = (['a1', 'b1'], (['a2', 'b2'], ['a3', 'b3']))
+        a = (("a1", ("a2", "a3")), ("b1", ("b2", "b3")))
+        b = (["a1", "b1"], (["a2", "b2"], ["a3", "b3"]))
         b = tuplefy(b, types=tuple)
         assert b.unzip_leaf() == a
 
     def test_zip_unzip_leaf(self):
-        a = (('a1', ('a2', 'a3')), ('b1', ('b2', 'b3')))
+        a = (("a1", ("a2", "a3")), ("b1", ("b2", "b3")))
         a = tuplefy(a)
         assert a.zip_leaf().unzip_leaf() == a
 
     def test_np2torch2np(self):
         np.random.seed(123)
-        a = [np.random.normal(size=(i, j)).astype('float32') for i, j in [(2, 3), (1, 2)]]
+        a = [np.random.normal(size=(i, j)).astype("float32") for i, j in [(2, 3), (1, 2)]]
         a = tuplefy(a, np.random.choice(10, size=(4,)))
         b = a.to_tensor().to_numpy()
         assert_tupletree_equal(a, b)
@@ -121,14 +135,14 @@ class TestTupleTree:
     def test_torch2np2torch(self):
         torch.manual_seed(123)
         a = [torch.randn((i, j)) for i, j in [(2, 3), (1, 2)]]
-        a = tuplefy(a, torch.randint(10,(4,)))
+        a = tuplefy(a, torch.randint(10, (4,)))
         b = a.to_numpy().to_tensor()
         assert_tupletree_equal(a, b)
 
     def test_iloc(self):
         torch.manual_seed(123)
         a = [torch.randn((i, j)) for i, j in [(5, 3), (5, 2)]]
-        a = tuplefy(a, torch.randint(10,(5,)))
+        a = tuplefy(a, torch.randint(10, (5,)))
         b = tuplefy((a[0][0][:2], a[0][1][:2]), a[1][:2])
         a = a.iloc[:2]
         assert_tupletree_equal(a, b)
@@ -140,19 +154,19 @@ class TestTupleTree:
     def test_cat_lens(self):
         torch.manual_seed(123)
         a = [torch.randn((i, j)) for i, j in [(5, 3), (5, 2)]]
-        a = tuplefy(a, torch.randint(10,(5,)))
+        a = tuplefy(a, torch.randint(10, (5,)))
         assert a.repeat(3).cat().lens() == ((15, 15), 15)
 
     def test_cat_split(self):
         torch.manual_seed(123)
         a = [torch.randn((i, j)) for i, j in [(5, 3), (5, 2)]]
-        a = tuplefy(a, torch.randint(10,(5,)))
+        a = tuplefy(a, torch.randint(10, (5,)))
         for sub in a.repeat(3).cat().split(5):
             assert_tupletree_equal(a, sub)
 
     def test_stack_shapes(self):
         torch.manual_seed(123)
         a = [torch.randn((i, j)) for i, j in [(5, 3), (5, 2)]]
-        a = tuplefy(a, torch.randint(10,(5,)))
+        a = tuplefy(a, torch.randint(10, (5,)))
         b = tuplefy((torch.Size([3, 5, 3]), torch.Size([3, 5, 2])), torch.Size([3, 5]))
         assert_tupletree_equal(a.repeat(3).stack().shapes(), b)

--- a/tests/test_tupletree.py
+++ b/tests/test_tupletree.py
@@ -18,8 +18,8 @@ def test_tuplefy_not_list(inp, types):
     assert type(t[0]) is type(inp)
 
 
-@pytest.mark.parametrize("batch_size", [1, 3, 10, 12])
-@pytest.mark.parametrize("num_workers", [0, 1, 5])
+@pytest.mark.parametrize("batch_size", [1, 12])
+@pytest.mark.parametrize("num_workers", [0, 2])
 def test_make_data_loader_sorted(batch_size, num_workers):
     torch.manual_seed(123)
     a = tuplefy(torch.randn(10, 3), torch.randn(10))
@@ -30,8 +30,8 @@ def test_make_data_loader_sorted(batch_size, num_workers):
     assert_tupletree_equal(b.cat(), a)
 
 
-@pytest.mark.parametrize("batch_size", [1, 3, 10, 12])
-@pytest.mark.parametrize("num_workers", [0, 1, 5])
+@pytest.mark.parametrize("batch_size", [1, 12])
+@pytest.mark.parametrize("num_workers", [0, 2])
 def test_make_data_loader_unsorted(batch_size, num_workers):
     torch.manual_seed(123)
     a = tuplefy(torch.randn(10, 3), torch.randn(10))

--- a/torchtuples/__init__.py
+++ b/torchtuples/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """Haavard Kvamme"""
 __email__ = 'haavard.kvamme@gmail.com'
-__version__ = '0.2.0'
+__version__ = '0.2.1'
 
 try:
     import torch

--- a/torchtuples/base.py
+++ b/torchtuples/base.py
@@ -527,7 +527,7 @@ class Model(object):
             dl = input
         else:
             raise ValueError(
-                "Did not recognize data type. You can set `is_dataloader to `Ture`"
+                "Did not recognize data type. You can set `is_dataloader to `True`"
                 + " or `False` to force usage."
             )
 

--- a/torchtuples/base.py
+++ b/torchtuples/base.py
@@ -1,9 +1,6 @@
-
 """Model for fitting torch models.
 """
 import os
-import time
-import random
 from collections import OrderedDict, defaultdict
 import warnings
 import contextlib
@@ -18,12 +15,12 @@ from torchtuples.utils import make_name_hash, array_or_tensor, is_data, is_dl
 
 class Model(object):
     """Train torch models using dataloaders, tensors or np.arrays.
-    
+
     Arguments:
         net {torch.nn.Module} -- A torch module.
-    
+
     Keyword Arguments:
-        loss {function} -- Set function that is used for training 
+        loss {function} -- Set function that is used for training
             (e.g. binary_cross_entropy for torch) (default: {None})
         optimizer {Optimizer} -- A torch optimizer or similar. Preferrably use torchtuples.optim instead of
             torch.optim, as this allows for reinitialization, etc. If 'None' set to torchtuples.optim.AdamW.
@@ -51,6 +48,7 @@ class Model(object):
     log = model.fit(x, y, batch_size=32, epochs=30)
     log.plot()
     """
+
     def __init__(self, net, loss=None, optimizer=None, device=None):
         self.net = net
         if type(self.net) is str:
@@ -58,7 +56,7 @@ class Model(object):
         self.loss = loss
         self.optimizer = optimizer if optimizer is not None else AdamW
         self.set_device(device)
-        if not hasattr(self, 'make_dataloader_predict'):
+        if not hasattr(self, "make_dataloader_predict"):
             self.make_dataloader_predict = self.make_dataloader
         self._init_train_log()
         self.metrics = self._setup_metrics()
@@ -86,17 +84,19 @@ class Model(object):
                 If 'string': string is passed to torch.device('string').
         """
         if device is None:
-            device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+            device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         elif type(device) is str:
             device = torch.device(device)
         elif type(device) is int:
             device = torch.device(f"cuda:{device}")
         if type(device) is not torch.device:
-            raise ValueError("Argument `device` needs to be `None`, `string`, `int`, or `torch.device`," +
-                             f" got {type(device)}")
+            raise ValueError(
+                "Argument `device` needs to be `None`, `string`, `int`, or `torch.device`,"
+                + f" got {type(device)}"
+            )
         self._device = device
         self.net.to(self.device)
-    
+
     @property
     def optimizer(self):
         return self._optimizer
@@ -118,7 +118,7 @@ class Model(object):
         separatelly.
 
         This simply calls tupletree.make_dataloader, but is included to make
-        inheritance simpler. 
+        inheritance simpler.
 
         Arguments:
             data {tuple, np.array, tensor} -- Data in dataloader e.g. (x, y)
@@ -135,21 +135,23 @@ class Model(object):
         """
         dataloader = make_dataloader(data, batch_size, shuffle, num_workers, **kwargs)
         return dataloader
-    
+
     def _setup_train_info(self, dataloader):
-        self.fit_info = {'batches_per_epoch': len(dataloader)}
+        self.fit_info = {"batches_per_epoch": len(dataloader)}
+
         def _tuple_info(tuple_):
             tuple_ = tuplefy(tuple_)
-            return {'levels': tuple_.to_levels(), 'shapes': tuple_.shapes().apply(lambda x: x[1:])}
+            return {"levels": tuple_.to_levels(), "shapes": tuple_.shapes().apply(lambda x: x[1:])}
+
         data = _get_element_in_dataloader(dataloader)
         if data is not None:
             if len(data) == 2:
                 try:
                     input, target = data
-                    self.fit_info['input'] = _tuple_info(input)
+                    self.fit_info["input"] = _tuple_info(input)
                 except:
                     pass
-    
+
     def _to_device(self, data) -> TupleTree:
         """Move `data` to self.device.
         If `data` is a tensor, it will be returned as a `TupleTree`.
@@ -160,7 +162,7 @@ class Model(object):
 
     def compute_metrics(self, data, metrics=None) -> Dict[str, torch.Tensor]:
         """Function for computing the loss and other metrics.
-        
+
         Arguments:
             data {tensor or tuple} -- A batch of data. Typically the tuple `(input, target)`.
 
@@ -180,30 +182,31 @@ class Model(object):
         return {name: metric(*out, *target) for name, metric in metrics.items()}
 
     def _setup_metrics(self, metrics=None):
-        all_metrics = {'loss': self.loss}
+        all_metrics = {"loss": self.loss}
         if metrics is not None:
-            if not hasattr(metrics, 'items'):
-                if not hasattr(metrics, '__iter__'):
+            if not hasattr(metrics, "items"):
+                if not hasattr(metrics, "__iter__"):
                     metrics = [metrics]
                 metrics = {met.__name__: met for met in metrics}
-            if 'loss' in metrics:
+            if "loss" in metrics:
                 raise ValueError("The 'loss' keyword is reserved for the loss function.")
             all_metrics.update(metrics)
         return all_metrics
 
-    def fit_dataloader(self, dataloader, epochs=1, callbacks=None, verbose=True, metrics=None,
-                       val_dataloader=None):
+    def fit_dataloader(
+        self, dataloader, epochs=1, callbacks=None, verbose=True, metrics=None, val_dataloader=None
+    ):
         """Fit a dataloader object.
         See 'fit' for tensors and np.arrays.
-        
+
         Arguments:
             dataloader {dataloader} -- A dataloader that gives (input, target).
-        
+
         Keyword Arguments:
             epochs {int} -- Number of epochs (default: {1})
             callbacks {list} -- list of callbacks (default: {None})
             verbose {bool} -- Print progress (default: {True})
-        
+
         Returns:
             TrainingLogger -- Training log
         """
@@ -213,41 +216,59 @@ class Model(object):
         self.val_metrics.dataloader = val_dataloader
         if callbacks is None:
             callbacks = []
-        self.callbacks = cb.TrainingCallbackHandler(self.optimizer, self.train_metrics, self.log,
-                                                    self.val_metrics, callbacks)
+        self.callbacks = cb.TrainingCallbackHandler(
+            self.optimizer, self.train_metrics, self.log, self.val_metrics, callbacks
+        )
         self.callbacks.give_model(self)
 
         stop = self.callbacks.on_fit_start()
         for _ in range(epochs):
-            if stop: break
+            if stop:
+                break
             stop = self.callbacks.on_epoch_start()
-            if stop: break
+            if stop:
+                break
             for data in dataloader:
                 stop = self.callbacks.on_batch_start()
-                if stop: break
+                if stop:
+                    break
                 self.optimizer.zero_grad()
                 self.batch_metrics = self.compute_metrics(data, self.metrics)
-                self.batch_loss = self.batch_metrics['loss']
+                self.batch_loss = self.batch_metrics["loss"]
                 self.batch_loss.backward()
                 stop = self.callbacks.before_step()
-                if stop: break
+                if stop:
+                    break
                 self.optimizer.step()
                 stop = self.callbacks.on_batch_end()
-                if stop: break
+                if stop:
+                    break
             else:
                 stop = self.callbacks.on_epoch_end()
         self.callbacks.on_fit_end()
         return self.log
 
-    def fit(self, input, target=None, batch_size=256, epochs=1, callbacks=None, verbose=True,
-            num_workers=0, shuffle=True, metrics=None, val_data=None, val_batch_size=8224,
-            **kwargs):
+    def fit(
+        self,
+        input,
+        target=None,
+        batch_size=256,
+        epochs=1,
+        callbacks=None,
+        verbose=True,
+        num_workers=0,
+        shuffle=True,
+        metrics=None,
+        val_data=None,
+        val_batch_size=8224,
+        **kwargs,
+    ):
         """Fit  model with inputs and targets.
-        
+
         Arguments:
             input {np.array, tensor or tuple} -- Input (x) passed to net.
             target {np.array, tensor or tuple} -- Target (y) passed to loss function.
-        
+
         Keyword Arguments:
             batch_size {int} -- Elemets in each batch (default: {256})
             epochs {int} -- Number of epochs (default: {1})
@@ -258,7 +279,7 @@ class Model(object):
             **kwargs -- Passed to the 'make_dataloader' method. Set e.g. `torch_ds_dl to use
                 the TensorDataset and DataLoader provided by torch instead of the torchtuples
                 implementations.
-    
+
         Returns:
             TrainingLogger -- Training log
         """
@@ -267,15 +288,16 @@ class Model(object):
         dataloader = self.make_dataloader(input, batch_size, shuffle, num_workers, **kwargs)
         val_dataloader = val_data
         if (is_dl(val_data) is False) and (val_data is not None):
-            val_dataloader = self.make_dataloader(val_data, val_batch_size, shuffle=False,
-                                                  num_workers=num_workers, **kwargs)
+            val_dataloader = self.make_dataloader(
+                val_data, val_batch_size, shuffle=False, num_workers=num_workers, **kwargs
+            )
         log = self.fit_dataloader(dataloader, epochs, callbacks, verbose, metrics, val_dataloader)
         return log
 
     @contextlib.contextmanager
     def _lr_finder(self, lr_min, lr_max, lr_range, n_steps, tolerance, verbose):
         lr_lower, lr_upper = lr_range
-        path = make_name_hash('lr_finder_checkpoint')
+        path = make_name_hash("lr_finder_checkpoint")
         self.save_model_weights(path)
         try:
             self.optimizer.drop_scheduler()
@@ -293,20 +315,51 @@ class Model(object):
         self.optimizer = self.optimizer.reinitialize(lr=lr)
         self._init_train_log()
 
-    def lr_finder(self, input, target, batch_size=256, lr_min=1e-4, lr_max=1., lr_range=(1e-7, 10.),
-                  n_steps=100, tolerance=np.inf, callbacks=None, verbose=False, num_workers=0,
-                  shuffle=True, **kwargs):
+    def lr_finder(
+        self,
+        input,
+        target,
+        batch_size=256,
+        lr_min=1e-4,
+        lr_max=1.0,
+        lr_range=(1e-7, 10.0),
+        n_steps=100,
+        tolerance=np.inf,
+        callbacks=None,
+        verbose=False,
+        num_workers=0,
+        shuffle=True,
+        **kwargs,
+    ):
         with self._lr_finder(lr_min, lr_max, lr_range, n_steps, tolerance, verbose) as lr_finder:
             if callbacks is None:
                 callbacks = []
             callbacks.append(lr_finder)
             epochs = n_steps
-            self.fit(input, target, batch_size, epochs, callbacks, verbose, num_workers,
-                        shuffle, **kwargs)
+            self.fit(
+                input,
+                target,
+                batch_size,
+                epochs,
+                callbacks,
+                verbose,
+                num_workers,
+                shuffle,
+                **kwargs,
+            )
         return lr_finder
 
-    def lr_finder_dataloader(self, dataloader, lr_min=1e-4, lr_max=1., lr_range=(1e-7, 10.),
-                             n_steps=100, tolerance=np.inf, callbacks=None, verbose=False):
+    def lr_finder_dataloader(
+        self,
+        dataloader,
+        lr_min=1e-4,
+        lr_max=1.0,
+        lr_range=(1e-7, 10.0),
+        n_steps=100,
+        tolerance=np.inf,
+        callbacks=None,
+        verbose=False,
+    ):
         with self._lr_finder(lr_min, lr_max, lr_range, n_steps, tolerance, verbose) as lr_finder:
             if callbacks is None:
                 callbacks = []
@@ -315,16 +368,28 @@ class Model(object):
             self.fit_dataloader(dataloader, epochs, callbacks, verbose)
         return lr_finder
 
-    def score_in_batches(self, input, target=None, score_func=None, batch_size=8224, eval_=True, mean=True,
-                         num_workers=0, shuffle=False, make_dataloader=None, numpy=True, **kwargs):
+    def score_in_batches(
+        self,
+        input,
+        target=None,
+        score_func=None,
+        batch_size=8224,
+        eval_=True,
+        mean=True,
+        num_workers=0,
+        shuffle=False,
+        make_dataloader=None,
+        numpy=True,
+        **kwargs,
+    ):
         """Used to score a dataset in batches.
         If score_func is None, this use the loss function.
         If make_dataloader is None, we use self.make_dataloader_predict, unless score_func is also
         None, in which we use self.make_dataloader.
-        
+
         Arguments:
             data {np.array, tensor, tuple, dataloader} -- Data in the form a datloader, or arrarys/tensors.
-        
+
         Keyword Arguments:
             score_func {func} -- Function used for scoreing. If None, we use self.loss. (default: {None})
             batch_size {int} -- Batch size (default: {8224})
@@ -335,7 +400,7 @@ class Model(object):
             make_dataloader {func} -- Function for making a dataloder.
                 If None, we use make_dataloader_predict as long as score_func is not None. (default: {None})
             **kwargs -- Are passed to make_dataloader function.
-        
+
         Returns:
             np.array -- Scores
         """
@@ -349,9 +414,11 @@ class Model(object):
         dl = make_dataloader(input, batch_size, shuffle, num_workers, **kwargs)
         scores = self.score_in_batches_dataloader(dl, score_func, eval_, mean, numpy)
         return scores
-    
-    def score_in_batches_dataloader(self, dataloader, score_func=None, eval_=True, mean=True, numpy=True):
-        '''Score a dataset in batches.
+
+    def score_in_batches_dataloader(
+        self, dataloader, score_func=None, eval_=True, mean=True, numpy=True
+    ):
+        """Score a dataset in batches.
 
         Parameters:
             dataloader: Dataloader:
@@ -359,7 +426,7 @@ class Model(object):
                 If None, we get training loss.
             eval_: If net should be in eval mode.
             mean: If return mean or list with scores.
-        '''
+        """
         if eval_:
             self.net.eval()
         batch_scores = []
@@ -368,7 +435,9 @@ class Model(object):
                 if score_func is None:
                     score = self.compute_metrics(data, self.metrics)
                 else:
-                    warnings.warn(f"score_func {score_func} probably doesn't work... Not implemented")
+                    warnings.warn(
+                        f"score_func {score_func} probably doesn't work... Not implemented"
+                    )
                     input, target = data
                     score = score_func(self, input, target)
                 batch_scores.append(score)
@@ -390,23 +459,29 @@ class Model(object):
             return np.mean(batch_scores)
         return batch_scores
 
-    def _predict_func_dl(self, func, dataloader, numpy=False, eval_=True, grads=False, to_cpu=False):
+    def _predict_func_dl(
+        self, func, dataloader, numpy=False, eval_=True, grads=False, to_cpu=False
+    ):
         """Get predictions from `dataloader`.
         `func` can be anything and is not concatenated to `self.net` or `self.net.predict`.
         This is different from `predict` and `predict_net` which both use call `self.net`.
         """
-        if hasattr(self, 'fit_info') and (self.make_dataloader is self.make_dataloader_predict):
+        if hasattr(self, "fit_info") and (self.make_dataloader is self.make_dataloader_predict):
             data = _get_element_in_dataloader(dataloader)
             if data is not None:
                 input = tuplefy(data)
-                input_train = self.fit_info['input']
-                if input.to_levels() != input_train['levels']:
-                    warnings.warn("""The input from the dataloader is different from
+                input_train = self.fit_info["input"]
+                if input.to_levels() != input_train["levels"]:
+                    warnings.warn(
+                        """The input from the dataloader is different from
                     the 'input' during trainig. Make sure to remove 'target' from dataloader.
-                    Can be done with 'torchtuples.data.dataloader_input_only'.""")
-                if input.shapes().apply(lambda x: x[1:]) != input_train['shapes']:
-                    warnings.warn("""The input from the dataloader is different from
-                    the 'input' during trainig. The shapes are different.""")
+                    Can be done with 'torchtuples.data.dataloader_input_only'."""
+                    )
+                if input.shapes().apply(lambda x: x[1:]) != input_train["shapes"]:
+                    warnings.warn(
+                        """The input from the dataloader is different from
+                    the 'input' during trainig. The shapes are different."""
+                    )
 
         if eval_:
             self.net.eval()
@@ -416,7 +491,7 @@ class Model(object):
                 input = tuplefy(input).to_device(self.device)
                 preds_batch = tuplefy(func(*input))
                 if numpy or to_cpu:
-                    preds_batch = preds_batch.to_device('cpu')
+                    preds_batch = preds_batch.to_device("cpu")
                 preds.append(preds_batch)
         if eval_:
             self.net.train()
@@ -427,33 +502,58 @@ class Model(object):
             preds = preds[0]
         return preds
 
-    def _predict_func(self, func, input, batch_size=8224, numpy=None, eval_=True, grads=False, to_cpu=False,
-                     num_workers=0, is_dataloader=None, **kwargs):
+    def _predict_func(
+        self,
+        func,
+        input,
+        batch_size=8224,
+        numpy=None,
+        eval_=True,
+        grads=False,
+        to_cpu=False,
+        num_workers=0,
+        is_dataloader=None,
+        **kwargs,
+    ):
         """Get predictions from `input` which can be data or a DataLoader.
         `func` can be anything and is not concatenated to `self.net` or `self.net.predict`.
         This is different from `predict` and `predict_net` which both use call `self.net`.
         """
         if is_data(input) or (is_dataloader is False):
-            dl = self.make_dataloader_predict(input, batch_size, shuffle=False,
-                                              num_workers=num_workers, **kwargs)
+            dl = self.make_dataloader_predict(
+                input, batch_size, shuffle=False, num_workers=num_workers, **kwargs
+            )
         elif is_dl(input) or (is_dataloader is True):
             dl = input
         else:
-            raise ValueError("Did not recognize data type. You can set `is_dataloader to `Ture`" +
-                             + " or `False` to force usage.")
+            raise ValueError(
+                "Did not recognize data type. You can set `is_dataloader to `Ture`"
+                + " or `False` to force usage."
+            )
 
         to_cpu = numpy or to_cpu
         preds = self._predict_func_dl(func, dl, numpy, eval_, grads, to_cpu)
         return array_or_tensor(preds, numpy, input)
 
-    def predict_net(self, input, batch_size=8224, numpy=None, eval_=True, grads=False, to_cpu=False,
-                num_workers=0, is_dataloader=None, func=None, **kwargs):
+    def predict_net(
+        self,
+        input,
+        batch_size=8224,
+        numpy=None,
+        eval_=True,
+        grads=False,
+        to_cpu=False,
+        num_workers=0,
+        is_dataloader=None,
+        func=None,
+        **kwargs,
+    ):
         """Get predictions from 'input' using the `self.net(x)` method.
         Use `predict` instead if you want to use `self.net.predict(x)`.
-        
+
         Arguments:
             input {dataloader, tuple, np.ndarra, or torch.tensor} -- Input to net.
-        
+
         Keyword Arguments:
             batch_size {int} -- Batch size (default: {8224})
             numpy {bool} -- 'False' gives tensor, 'True' gives numpy, and None give same as input
@@ -466,23 +566,44 @@ class Model(object):
             func {func} -- A toch function, such as `torch.sigmoid` which is called after the predict.
                 (default: {None})
             **kwargs -- Passed to make_dataloader.
-        
+
         Returns:
             [TupleTree, np.ndarray or tensor] -- Predictions
         """
         pred_func = wrapfunc(func, self.net)
-        preds = self._predict_func(pred_func, input, batch_size, numpy, eval_, grads, to_cpu, num_workers,
-                                  is_dataloader, **kwargs)
+        preds = self._predict_func(
+            pred_func,
+            input,
+            batch_size,
+            numpy,
+            eval_,
+            grads,
+            to_cpu,
+            num_workers,
+            is_dataloader,
+            **kwargs,
+        )
         return array_or_tensor(preds, numpy, input)
 
-    def predict(self, input, batch_size=8224, numpy=None, eval_=True, grads=False, to_cpu=False,
-                num_workers=0, is_dataloader=None, func=None, **kwargs):
+    def predict(
+        self,
+        input,
+        batch_size=8224,
+        numpy=None,
+        eval_=True,
+        grads=False,
+        to_cpu=False,
+        num_workers=0,
+        is_dataloader=None,
+        func=None,
+        **kwargs,
+    ):
         """Get predictions from 'input' using the `self.net.predict(x)` method.
         Use `predict_net` instead if you want to use `self.net(x)`.
-        
+
         Arguments:
             input {dataloader, tuple, np.ndarra, or torch.tensor} -- Input to net.
-        
+
         Keyword Arguments:
             batch_size {int} -- Batch size (default: {8224})
             numpy {bool} -- 'False' gives tensor, 'True' gives numpy, and None give same as input
@@ -495,44 +616,64 @@ class Model(object):
             func {func} -- A toch function, such as `torch.sigmoid` which is called after the predict.
                 (default: {None})
             **kwargs -- Passed to make_dataloader.
-        
+
         Returns:
             [TupleTree, np.ndarray or tensor] -- Predictions
         """
-        if not hasattr(self.net, 'predict'):
-            return self.predict_net(input, batch_size, numpy, eval_, grads, to_cpu, num_workers,
-                                    is_dataloader, func, **kwargs)
+        if not hasattr(self.net, "predict"):
+            return self.predict_net(
+                input,
+                batch_size,
+                numpy,
+                eval_,
+                grads,
+                to_cpu,
+                num_workers,
+                is_dataloader,
+                func,
+                **kwargs,
+            )
 
         pred_func = wrapfunc(func, self.net.predict)
-        preds = self._predict_func(pred_func, input, batch_size, numpy, eval_, grads, to_cpu, num_workers,
-                                  is_dataloader, **kwargs)
+        preds = self._predict_func(
+            pred_func,
+            input,
+            batch_size,
+            numpy,
+            eval_,
+            grads,
+            to_cpu,
+            num_workers,
+            is_dataloader,
+            **kwargs,
+        )
         return array_or_tensor(preds, numpy, input)
 
     def save_model_weights(self, path, **kwargs):
-        '''Save the model weights.
+        """Save the model weights.
 
         Parameters:
             path: The filepath of the model.
             **kwargs: Arguments passed to torch.save method.
-        '''
+        """
         return torch.save(self.net.state_dict(), path, **kwargs)
 
     def load_model_weights(self, path, **kwargs):
-        '''Load model weights.
+        """Load model weights.
 
         Parameters:
             path: The filepath of the model.
             **kwargs: Arguments passed to torch.load method.
-        '''
+        """
         self.net.load_state_dict(torch.load(path, **kwargs))
 
     def save_net(self, path, **kwargs):
         """Save self.net to file (e.g. net.pt).
-        
+
         Arguments:
             path {str} -- Path to file.
             **kwargs are passed to torch.save
-        
+
         Returns:
             None
         """
@@ -540,16 +681,16 @@ class Model(object):
 
     def load_net(self, path, **kwargs):
         """Load net from file (e.g. net.pt), and set as self.net
-        
+
         Arguments:
             path {str} -- Path to file.
             **kwargs are passed to torch.load
-        
+
         Returns:
             torch.nn.Module -- self.net
         """
         self.net = torch.load(path, **kwargs)
-        if hasattr(self, 'device'):
+        if hasattr(self, "device"):
             self.net.to(self.device)
         return self.net
 
@@ -570,12 +711,15 @@ def _get_element_in_dataloader(dataloader):
         pass
     return None
 
+
 def wrapfunc(outer, inner):
     """Essentially returns the function `lambda x: outer(inner(x))`
     If `outer` is None, return `inner`.
     """
     if outer is None:
         return inner
+
     def newfun(*args, **kwargs):
         return outer(inner(*args, **kwargs))
+
     return newfun

--- a/torchtuples/tupletree.py
+++ b/torchtuples/tupletree.py
@@ -1,7 +1,10 @@
 import functools
 import itertools
+from typing import Any, Union
+
 import numpy as np
 import torch
+
 import torchtuples
 
 
@@ -309,7 +312,7 @@ def tuplefy(*data, types=(list, tuple), stop_at_tuple=True):
 
 
 @apply_leaf
-def to_device(data, device):
+def to_device(data: Any, device: Union[str, torch.device]) -> Any:
     """Move data to device
 
     Arguments:
@@ -319,8 +322,6 @@ def to_device(data, device):
     Returns:
         TupleTree, tensor -- Data moved to device
     """
-    if type(data) is not torch.Tensor:
-        raise RuntimeError(f"Need 'data' to be tensors, not {type(data)}.")
     return data.to(device)
 
 


### PR DESCRIPTION
Allow all objects that implements the `to` method to move between cpu and gpu, instead of raising an error