### PR TITLE
Don't crash on fit_into["input"]

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.1
+current_version = 0.2.2
 commit = True
 tag = False
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ requirements = [
 
 setup(
     name='torchtuples',
-    version='0.2.1',
+    version='0.2.2',
     description="Training neural networks in PyTorch",
     long_description=readme,
     long_description_content_type='text/markdown',

--- a/torchtuples/__init__.py
+++ b/torchtuples/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """Haavard Kvamme"""
 __email__ = 'haavard.kvamme@gmail.com'
-__version__ = '0.2.1'
+__version__ = '0.2.2'
 
 try:
     import torch

--- a/torchtuples/base.py
+++ b/torchtuples/base.py
@@ -470,18 +470,19 @@ class Model(object):
             data = _get_element_in_dataloader(dataloader)
             if data is not None:
                 input = tuplefy(data)
-                input_train = self.fit_info["input"]
-                if input.to_levels() != input_train["levels"]:
-                    warnings.warn(
-                        """The input from the dataloader is different from
-                    the 'input' during trainig. Make sure to remove 'target' from dataloader.
-                    Can be done with 'torchtuples.data.dataloader_input_only'."""
-                    )
-                if input.shapes().apply(lambda x: x[1:]) != input_train["shapes"]:
-                    warnings.warn(
-                        """The input from the dataloader is different from
-                    the 'input' during trainig. The shapes are different."""
-                    )
+                input_train = self.fit_info.get("input")
+                if input_train is not None:
+                    if input.to_levels() != input_train.get("levels"):
+                        warnings.warn(
+                            """The input from the dataloader is different from
+                        the 'input' during trainig. Make sure to remove 'target' from dataloader.
+                        Can be done with 'torchtuples.data.dataloader_input_only'."""
+                        )
+                    if input.shapes().apply(lambda x: x[1:]) != input_train.get("shapes"):
+                        warnings.warn(
+                            """The input from the dataloader is different from
+                        the 'input' during trainig. The shapes are different."""
+                        )
 
         if eval_:
             self.net.eval()


### PR DESCRIPTION
This functionality is just there to give better feedback when the user has something wrong with the test data, and the code should not crash when it cannot access the "input" attribute